### PR TITLE
fix: Make sure to initialize values

### DIFF
--- a/src/threshold_line.vala
+++ b/src/threshold_line.vala
@@ -9,6 +9,7 @@ namespace LiveChart {
         public ThresholdLine(double value) {
             base();
             this.value = value;
+            this.values = new Values();
         }
 
         public override void draw(Context ctx, Config config) {


### PR DESCRIPTION
Fixes #46

ThresholdLine misses initialization of values member variable in the parent SerieRenderer. This causes null access when Chart.add_serie() is called.