### PR TITLE
meson: Add version to the shared library

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -52,6 +52,7 @@ livechart_lib = library(
     [sources],
     dependencies: deps,
     vala_args: vala_args,
+    version: meson.project_version(),
     install: true,
     install_dir: [true, true, true]
 )


### PR DESCRIPTION
I'm currently working on Debian packaging of live-chart and lintian, the Debian package checker, complains this:

![Screenshot From 2025-01-10 21-54-49](https://github.com/user-attachments/assets/06a7d5b7-f4d9-4319-b406-5cbaf340cd94)

This PR fixes the above warning.